### PR TITLE
Update to winget v1.3.12510-preview

### DIFF
--- a/DA-AppUpdater/config/about.xml
+++ b/DA-AppUpdater/config/about.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <app>
     <name>DA App Updater (DAAU)</name>
-    <version>1.4.1</version>
+    <version>1.4.2</version>
     <author>Doherty Associates</author>
     <info>https://github.com/DohertyAssociates/DA-AppUpdater</info>
     <attrib>Based on work by Romanitho/Winget-AutoUpdate</attrib>

--- a/DA-AppUpdater/functions/Get-WingetCmd.ps1
+++ b/DA-AppUpdater/functions/Get-WingetCmd.ps1
@@ -28,7 +28,7 @@ function Get-WingetCmd {
     & $Winget list --accept-source-agreements | Out-Null
 
     #Log Winget installed version
-    $WingerVer = & $Winget --version
-    Write-Log "Winget Version: $WingerVer"
+    $WingetVer = & $Winget --version
+    Write-Log "Winget Version: $WingetVer"
     Return $true
 }

--- a/Install-DAAppUpdater.ps1
+++ b/Install-DAAppUpdater.ps1
@@ -142,13 +142,14 @@ function Install-WinGet {
     #Check Package Install
     Write-Host "Checking if Winget is installed" -ForegroundColor Yellow
     $TestWinGet = Get-AppxProvisionedPackage -Online | Where-Object {$_.DisplayName -eq "Microsoft.DesktopAppInstaller"}
-    If ([Version]$TestWinGet.Version -gt "2022.127.2322.0") {
+    If ([Version]$TestWinGet.Version -gt "2022.506.16.0") {
         Write-Host "WinGet is Installed" -ForegroundColor Green
     }
     Else {
         #Download WinGet MSIXBundle
         Write-Host "Not installed. Downloading WinGet..."
-        $WinGetURL = "https://aka.ms/getwinget"
+        #$WinGetURL = "https://aka.ms/getwinget"
+        $WinGetURL = "https://github.com/microsoft/winget-cli/releases/download/v1.3.1251-preview/Microsoft.DesktopAppInstaller_8wekyb3d8bbwe.msixbundle" #Current preview version to allow install of MSStoreApps without MSA Account
         $WebClient.DownloadFile($WinGetURL, "$DAInstallerFolder\Microsoft.DesktopAppInstaller_8wekyb3d8bbwe.msixbundle")
 
         #Install WinGet MSIXBundle


### PR DESCRIPTION
Updated to [Winget Preview version 1.3.1251](https://github.com/microsoft/winget-cli/releases/tag/v1.3.1251-preview) which fixes a number of bugs, including not being able to install packages from the MSStore without MSA authentication.